### PR TITLE
docs: Fix some image source file URIs

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -79,7 +79,7 @@ Graphical Representation
 
 The architecture is presented below:
 
-.. image:: /images/arch.png
+.. image:: images/arch.png
 
 
 .. _storage-backends:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 Welcome to snf-image's documentation!
 =====================================
 
-.. image:: /images/logo.png
+.. image:: images/logo.png
 
 snf-image is a `Ganeti <http://code.google.com/p/ganeti/>`_ OS definition. It
 allows Ganeti to launch instances from predefined or untrusted custom Images.


### PR DESCRIPTION
In the image directives always use relative paths for images that are
hosted inside the project's repository.
