### PR TITLE
Support for putting settings into variants files

### DIFF
--- a/snf-image-host/common.sh.in
+++ b/snf-image-host/common.sh.in
@@ -167,7 +167,7 @@ get_api20_arguments() {
 
         # Store OSP_VAR in VAR
         for param in $osparams; do
-            eval $param=\"\$OSP_$param\"
+            eval $param=\"\${OSP_$param:-\$$param}\"
         done
 
         if [ -n "$CONFIG_URL" ]; then
@@ -288,6 +288,8 @@ canonicalize() {
 
 # this one is only to be called by create
 ganeti_os_main() {
+    ganeti_os_variant
+
     if [ -z "$OS_API_VERSION" -o "$OS_API_VERSION" = "5" ]; then
         OS_API_VERSION=5
         GETOPT_RESULT=`getopt -o o:n:i:b:s: -n '$0' -- "$@"`
@@ -304,7 +306,9 @@ ganeti_os_main() {
         log_error "Unknown OS API VERSION $OS_API_VERSION"
         exit 1
     fi
-    
+}
+
+ganeti_os_variant() {
     if [ -n "$OS_VARIANT" ]; then
         if [ ! -d "$VARIANTS_DIR" ]; then
             log_error "OS Variants directory $VARIANTS_DIR doesn't exist"

--- a/snf-image-host/verify
+++ b/snf-image-host/verify
@@ -21,6 +21,7 @@ set -e
 
 . common.sh
 
+ganeti_os_variant
 
 check_required() {
     local required_params="IMG_ID IMG_FORMAT IMG_PASSWD"
@@ -28,7 +29,7 @@ check_required() {
 
     # Store OSP_VAR in VAR
     for param in $osparams; do
-        eval $param=\"\$OSP_$param\"
+        eval $param=\"\${OSP_$param:-\$$param}\"
     done
 
     for var in $required_params; do


### PR DESCRIPTION
This patch allows you to create (say) `/etc/ganeti/snf-image/variants/wheezy.conf` with

```
IMG_PASSWD=abc123
IMG_FORMAT=diskdump
IMG_ID=debian_base-7.0-x86_64
IMG_PROPERTIES='{"OSFAMILY":"linux","ROOT_PARTITION":"1","USERS":"root"}'
```

then you can create an instance with `-o snf-image+wheezy` without having to provide any -O options on the command line. Any -O options you _do_ provide override those in the conf file, so `-O img_passwd=def456` works as expected.

The main change is in ganeti_os_main() so that it reads the variants file _before_ parsing the options. This is done by making a separate function ganeti_os_variant(), which is also called from the 'verify' script.
