### PR TITLE
Fix a bug in the usage of $EXP_SIZE_FD in export

### DIFF
--- a/snf-image-host/export
+++ b/snf-image-host/export
@@ -34,8 +34,8 @@ fi
 
 # Export disk's predicted size to Ganeti.
 # Used to provide a time estimate of the export process to the user.
-if [ -z "$EXP_SIZE_FD" ]; then
-    blockdev --getsize64 $blockdev >&$EXP_SIZE_FD
+if [ -n "$EXP_SIZE_FD" ]; then
+    blockdev --getsize64 "$blockdev" >&$EXP_SIZE_FD
 fi
 
 dd if="$blockdev" bs=4M


### PR DESCRIPTION
Fix a bug in export script where the check of whether to use the
$EXP_SIZE_FD file descriptor was wrong.

This fixes #47
