### PR TITLE
Allow newlines and other control characters in JSON string literals.

### DIFF
--- a/snf-image-helper/decode-properties.py
+++ b/snf-image-helper/decode-properties.py
@@ -60,7 +60,7 @@ def main():
     infh = sys.stdin if input_file is None else open(input_file, 'r')
     outfh = open(output_file, 'w')
 
-    properties = json.load(infh)
+    properties = json.load(infh, strict=False)
     for key, value in properties.items():
         os.environ['SNF_IMAGE_PROPERTY_' + str(key).upper()] = value
 

--- a/snf-image-helper/inject-files.py
+++ b/snf-image-helper/inject-files.py
@@ -73,7 +73,7 @@ def parse_arguments(input_args):
 def main():
     (input_file, target, decode) = parse_arguments(sys.argv[1:])
 
-    files = json.load(input_file)
+    files = json.load(input_file, strict=False)
 
     if decode:
         manifest = open(target + '/manifest', 'w')


### PR DESCRIPTION
This is to allow multi-line base64 encoded data in the "contents" attribute of img_personality. (There's no particular reason to allow newlines in img_properties but I did this for consistency)

Fixes #51

Tested by loopback-mounting `/var/lib/snf-image/helper/image` and manually modifying
- /usr/lib/snf-image-helper/decode-properties.py
- /usr/lib/snf-image-helper/inject-files.py
