### PR TITLE
pithcat: Fix a bug when using Synnefo version 0.16

### DIFF
--- a/snf-image-host/pithcat
+++ b/snf-image-host/pithcat
@@ -187,7 +187,8 @@ def main():
 
             data_path = environ['PITHCAT_INPUT_DATA'] if not options.data else \
                 options.data
-    else:
+    elif parse_version(pithos_backend_version) < \
+            parse_version(SELECTABLE_BE_VER):
         if not options.data and 'PITHCAT_INPUT_DATA' not in environ:
             stderr.write(
                 "Pithos data directory path is missing.\n"


### PR DESCRIPTION
PITHOS_INPUT_DATA env variable and '--data' option are not used
in Synnefo version 0.16.
