### PR TITLE
pithcat: Use ModularBackend class version attribute

### DIFF
--- a/snf-image-host/pithcat
+++ b/snf-image-host/pithcat
@@ -40,7 +40,8 @@ except ImportError:
     exit(2)
 
 SELECTABLE_BE_VER = "0.15.1"
-ARCHIPELAGO_BE_VER = "0.16.0"
+MB_NO_ARCHIPELAGO_VER = 0
+MB_ARCHIPELAGO_VER = 1
 
 note = """
 NOTE: You can pass all arguments through environment variables instead of
@@ -51,11 +52,15 @@ Using the --db argument directly is dangerous, because it may
 expose sensitive information in the output of 'ps'. Consider passing
 the DB URI through the environment variable PITHCAT_DB instead.\n"""
 
+try:
+    mb_version = ModularBackend._class_version
+except AttributeError:
+    mb_version = MB_NO_ARCHIPELAGO_VER
+
 OptionParser.format_epilog = lambda self, formattxt: self.epilog
 parser = OptionParser(usage='%prog [options] <URL>', epilog=note)
 if parse_version(pithos_backend_version) >= parse_version(SELECTABLE_BE_VER) \
-    and parse_version(pithos_backend_version) < \
-        parse_version(ARCHIPELAGO_BE_VER):
+        and mb_version == MB_NO_ARCHIPELAGO_VER:
     backend_group = OptionGroup(
         parser, "Backend-specific Options",
         "The backend-specific options depend on the specific "
@@ -78,13 +83,13 @@ if parse_version(pithos_backend_version) >= parse_version(SELECTABLE_BE_VER) \
                              help='path to the directory where data are stored'
                              )
     parser.add_option_group(backend_group)
-elif parse_version(pithos_backend_version) >= \
-        parse_version(ARCHIPELAGO_BE_VER):
-    parser.add_option('--archipelago-conf', dest='archipconf', metavar='ACONF',
-                      help='Archipelago configuration file to use')
-elif parse_version(pithos_backend_version) < parse_version(SELECTABLE_BE_VER):
+elif parse_version(pithos_backend_version) < parse_version(SELECTABLE_BE_VER) \
+        and mb_version == MB_NO_ARCHIPELAGO_VER:
     parser.add_option('--data', dest='data', metavar='DIR',
                       help='path to the directory where data are stored')
+elif mb_version == MB_ARCHIPELAGO_VER:
+    parser.add_option('--archipelago-conf', dest='archipconf', metavar='ACONF',
+                      help='Archipelago configuration file to use')
 
 parser.add_option('-s', action='store_true', dest='size', default=False,
                   help='print file size and exit')
@@ -127,8 +132,7 @@ def print_data(backend, url):
 
     if type(url) is LocationURL:
         account, container, object = url
-        if parse_version(pithos_backend_version) < \
-                parse_version(ARCHIPELAGO_BE_VER):
+        if mb_version == MB_NO_ARCHIPELAGO_VER:
             size, hashmap = backend.get_object_hashmap(account, account,
                                                        container,
                                                        object)
@@ -138,8 +142,7 @@ def print_data(backend, url):
                                                           object)
     elif type(url) is HashmapURL:
         size = int(url.size)
-        if parse_version(pithos_backend_version) < \
-                parse_version(ARCHIPELAGO_BE_VER):
+        if mb_version == MB_NO_ARCHIPELAGO_VER:
             hashmap = [hexlify(x)
                        for x in backend.store.map_get(unhexlify(url.hash))]
         else:
@@ -167,8 +170,7 @@ def main():
 
     if parse_version(pithos_backend_version) >= \
         parse_version(SELECTABLE_BE_VER) and \
-        parse_version(pithos_backend_version) < \
-            parse_version(ARCHIPELAGO_BE_VER):
+            mb_version == MB_NO_ARCHIPELAGO_VER:
 
         if not options.backend and 'PITHCAT_BACKEND_STORAGE' not in environ:
             stderr.write(
@@ -218,8 +220,7 @@ def main():
 
     if parse_version(pithos_backend_version) >= \
        parse_version(SELECTABLE_BE_VER) and \
-       parse_version(pithos_backend_version) < \
-       parse_version(ARCHIPELAGO_BE_VER):
+            mb_version == MB_NO_ARCHIPELAGO_VER:
 
         block_params = {'mappool': None, 'blockpool': None}
         rados_ceph_conf = None
@@ -274,8 +275,7 @@ def main():
                                  data_path, block_params=block_params,
                                  backend_storage=backend_storage,
                                  rados_ceph_conf=rados_ceph_conf)
-    elif parse_version(pithos_backend_version) >= \
-            parse_version(ARCHIPELAGO_BE_VER):
+    elif mb_version >= MB_ARCHIPELAGO_VER:
 
         if not options.archipconf and 'PITHCAT_ARCHIPELAGO_CONF' not \
                 in environ:
@@ -306,8 +306,7 @@ def main():
         else:
             print_data(backend, url)
     finally:
-        if parse_version(pithos_backend_version) >= \
-                parse_version(ARCHIPELAGO_BE_VER):
+        if mb_version >= MB_ARCHIPELAGO_VER:
             if backend.ioctx_pool:
                 backend.ioctx_pool._shutdown_pool()
         else:


### PR DESCRIPTION
ModularBackend introduced a class attribute that denotes
the class version. Since class version 1, ModularBackend
supports Archipelago as it's main storage backend. Use the
new class attribute to instantiate ModularBackend class
appropriately.
