### PR TITLE
Make the process of image copying modular

### DIFF
--- a/docs/interface.rst
+++ b/docs/interface.rst
@@ -48,17 +48,21 @@ Image ID (img_id)
 ^^^^^^^^^^^^^^^^^
 
 The **img_id** OS parameter points to the actual Image that we want to deploy.
-It is a URI and its prefix denotes the type of :ref:`backend <storage-backends>`
-to be used. If no prefix is used, it defaults to the local back-end:
+It is a URI and its prefix denotes the type of :ref:`image backend
+<source-backends>` to be used. If no prefix is used, it defaults to the file
+backend:
 
- * **Local backend**:
-   To select it, the prefix should be ``local://``, followed by the name of the
-   image. All local images are expected to be found under a predefined image
-   directory (``/var/lib/snf-image`` by default).
+ * **File backend**:
+   To select it, just pass the name of the image optionally prefixed with
+   either ``file://`` or ``local://``. All local images are expected to be found
+   under a predefined image directory (``/var/lib/snf-image`` by default).
+   The image will be fetched using ``dd``.
 
   | For example, if we want to deploy the image file:
   | ``/var/lib/snf-image/slackware.diskdump``
   | We need to assign:
+  | ``img_id=slackware.diskdump`` or
+  | ``img_id=file://slackware.diskdump``
   | ``img_id=local://slackware.diskdump``
 
  * **Network backend**:
@@ -86,7 +90,7 @@ to be used. If no prefix is used, it defaults to the local back-end:
   | ``img_id=pithosmap://<slackware-image-map-name>/<size>``
 
  * **Null backend**:
-   To select the Null back-end and skip the fetching and extraction step, we set
+   To select the Null backend and skip the fetching and extraction step, we set
    ``img_id=null``.
 
 .. _image-passwd:

--- a/snf-image-host/CONTRIBUTORS
+++ b/snf-image-host/CONTRIBUTORS
@@ -1,3 +1,4 @@
 # This is the official list of contributors for copyright purposes.
 GRNET S.A.
 Vangelis Koukis <vkoukis@gmail.com>
+Dimitris Aragiorgis <dimitris.aragiorgis@gmail.com>

--- a/snf-image-host/Makefile.am
+++ b/snf-image-host/Makefile.am
@@ -1,5 +1,7 @@
 osname=snf-image
 osdir=$(OS_DIR)/$(osname)
+backend_srcdir=$(osdir)/backends/src
+backend_dstdir=$(osdir)/backends/dst
 defaultdir=$(DEFAULT_DIR)
 exampledir = $(datarootdir)/doc/$(PACKAGE)
 variantsdir=${sysconfdir}/ganeti/snf-image/variants
@@ -9,6 +11,14 @@ dist_os_SCRIPTS = ${srcdir}/create ${srcdir}/import ${srcdir}/export \
 	${srcdir}/rename ${srcdir}/verify ${srcdir}/pithcat \
 	${srcdir}/copy-monitor.py ${srcdir}/helper-monitor.py \
 	${srcdir}/host-monitor.py ${srcdir}/decode-config.py
+
+dist_backend_src_SCRIPTS = \
+	${srcdir}/backends/src/file \
+	${srcdir}/backends/src/network \
+	${srcdir}/backends/src/pithos
+
+dist_backend_dst_SCRIPTS = \
+	${srcdir}/backends/dst/file
 
 dist_os_DATA = ${srcdir}/ganeti_api_version ${srcdir}/parameters.list \
                ${srcdir}/variants.list ${srcdir}/xen-common.sh \
@@ -57,6 +67,5 @@ install-exec-local:
 	@mkdir_p@ "$(DESTDIR)$(osdir)"
 	@mkdir_p@ "$(DESTDIR)$(variantsdir)"
 	touch "$(DESTDIR)$(variantsdir)/default.conf"
-	
 
 CLEANFILES = $(os_DATA) $(dist_bin_SCRIPTS) defaults version_pinning.pref

--- a/snf-image-host/backends/dst/file.in
+++ b/snf-image-host/backends/dst/file.in
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+
+. @osdir@/common.sh
+
+DISK=$1
+IMAGE_TYPE=$2
+
+case "$IMAGE_TYPE" in
+    ntfsdump|extdump)
+        # Create a corresponding blockdev if required
+        blockdev=$(losetup_disk "$DISK")
+
+        # Create partitions
+        format_disk0 "$blockdev" "$IMAGE_TYPE"
+
+        # Install a new MBR
+        $INSTALL_MBR -p 1 -i n "$blockdev"
+
+        # map_disk0 uses kpartx and returns the filesystem device e.g. /dev/mapper/loop0
+        # The target that we will dump our data will be the first partition
+        target="$(map_disk0 "$blockdev")-1"
+        add_cleanup unmap_disk0 "$blockdev"
+        ;;
+    diskdump)
+        target=$DISK
+        ;;
+esac
+
+$DD bs=4M of="$target" oflag=direct iflag=fullblock

--- a/snf-image-host/backends/src/file.in
+++ b/snf-image-host/backends/src/file.in
@@ -1,0 +1,61 @@
+#!/bin/bash -e
+
+. @osdir@/common.sh
+
+GET_SIZE=false
+
+while getopts "s" opt; do
+    case $opt in
+        s) GET_SIZE=true ;;
+    esac
+done
+
+shift $(($OPTIND - 1))
+
+IMAGE_NAME=$1
+IMAGE_TYPE=$2
+
+if [[ "$IMAGE_NAME" =~ ^local:// ]]; then
+    IMAGE_NAME="${IMAGE_NAME:8}"
+elif [[ "$IMAGE_NAME" =~ ^file:// ]]; then
+    IMAGE_NAME="${IMAGE_NAME:7}"
+    log_warning "The file:// backend identifier is deprecated and" \
+                "will be removed in the future. Use local:// instead."
+fi
+
+canonical_image_dir="$(canonicalize "$IMAGE_DIR")"
+if [ ! -d "$canonical_image_dir" ]; then
+    log_error "The IMAGE_DIR directory: \`$IMAGE_DIR' does not exist."
+    report_error "Unable to retrieve image file."
+    exit 1
+fi
+
+image_file="$IMAGE_DIR/$IMAGE_NAME"
+if [ ! -e "$image_file" ]; then
+    if [ -e "$image_file.$IMAGE_TYPE" ] ; then
+        image_file="$image_file.$IMAGE_TYPE"
+        log_warning "The \`.$IMAGE_TYPE' extension is missing from" \
+            "the local backend id. This id form is deprecated and" \
+            "will be remove in the future."
+    else
+        log_error "Image file \`$image_file' does not exist."
+        report_error "Unable to retrieve image file."
+        exit 1
+    fi
+fi
+
+canonical_image_file="$(canonicalize "$image_file")"
+
+if [[ "$canonical_image_file" != "$canonical_image_dir"* ]]; then
+    log_error "Image ID points to a file outside the image directory: \`$IMAGE_DIR'"
+    report_error "Invalid image ID"
+    exit 1
+fi
+
+if $GET_SIZE; then
+    stat -L -c %s "$image_file"
+else
+    $DD bs=4M if=$image_file iflag=fullblock
+fi
+
+exit 0

--- a/snf-image-host/backends/src/network.in
+++ b/snf-image-host/backends/src/network.in
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+. @osdir@/common.sh
+
+
+GET_SIZE=false
+
+while getopts "s" opt; do
+    case $opt in
+        s) GET_SIZE=true ;;
+    esac
+done
+
+shift $(($OPTIND - 1))
+
+IMAGE_NAME=$1
+
+if $GET_SIZE; then
+    $CURL -sI "$IMAGE_NAME" | grep ^Content-Length: | cut -d" " -f2
+else
+    $CURL $(printf "%q" "$IMAGE_NAME")
+fi
+
+exit 0

--- a/snf-image-host/backends/src/pithos.in
+++ b/snf-image-host/backends/src/pithos.in
@@ -1,0 +1,41 @@
+#!/bin/bash -e
+
+. @osdir@/common.sh
+
+# For security reasons pass the various options to pithcat as
+# environment variables.
+export PITHCAT_DB="$PITHOS_DB"
+export PITHCAT_DATA="$PITHOS_DATA"
+export PITHCAT_BACKEND_STORAGE="$PITHOS_BACKEND_STORAGE"
+export PITHCAT_RADOS_CEPH_CONF="$PITHOS_RADOS_CEPH_CONF"
+export PITHCAT_RADOS_POOL_MAPS="$PITHOS_RADOS_POOL_MAPS"
+export PITHCAT_RADOS_POOL_BLOCKS="$PITHOS_RADOS_POOL_BLOCKS"
+export PITHCAT_ARCHIPELAGO_CONF="$PITHOS_ARCHIPELAGO_CONF"
+
+GET_SIZE=false
+
+while getopts "s" opt; do
+    case $opt in
+        s) GET_SIZE=true ;;
+    esac
+done
+
+shift $(($OPTIND - 1))
+
+IMAGE_NAME=$1
+
+cmd_args=""
+if [ -n "${PITHCAT_UMASK+dummy}" ]; then
+    cmd_args="--umask=$PITHCAT_UMASK"
+fi
+cmd_args+=" $(printf "%q" "${IMAGE_NAME}")"
+
+if $GET_SIZE; then
+    @osdir@/pithcat -s $cmd_args
+else
+    @osdir@/pithcat $cmd_args
+fi
+
+exit 0
+
+

--- a/snf-image-host/common.sh.in
+++ b/snf-image-host/common.sh.in
@@ -307,8 +307,8 @@ create_floppy() {
     umount "$target"
 }
 
-get_backend_type() {
-    local id=$1
+get_src_backend_type() {
+    local id=$IMG_ID
 
     if [[ "$id" =~ ^pithos: ]]; then
         echo "pithos"
@@ -318,10 +318,32 @@ get_backend_type() {
         echo "network"
     elif [ "$id" = "null" ]; then
         echo "null"
+    # This matches a custom backend with IMG_ID:
+    #   <backend name>:<some custom identifier>
+    elif [[ "$id" =~ ^.*: ]]; then
+        # Find the backend name by stripping everything after the first colon
+        echo "${id%%:*}"
     else
-        echo "local"
+        echo "file"
     fi
 }
+
+get_dst_backend_type() {
+    local path=$DISK_0_PATH
+    local uri=$DISK_0_URI
+
+    # If we have a valid local path then use the file backend
+    if [ -b "$path" -o -f "$path" ]; then
+        echo "file"
+    # Otherwise if a URI with proper format is exported by Ganeti use a custom backend
+    elif [[ "$uri" =~ ^.*: ]]; then
+        echo "${uri%%:*}"
+    else
+        log_error "Cannot find a matching backend for destination disk"
+        exit 1
+    fi
+}
+
 
 canonicalize() {
     local name="$1"

--- a/snf-image-host/create
+++ b/snf-image-host/create
@@ -26,9 +26,8 @@ ganeti_os_main
 
 parameter_check
 
-IMAGE_NAME="$IMG_ID"
-IMAGE_TYPE="$IMG_FORMAT"
-BACKEND_TYPE=$(get_backend_type $IMG_ID)
+SRC_BACKEND_TYPE=$(get_src_backend_type)
+DST_BACKEND_TYPE=$(get_dst_backend_type)
 
 if [ "$IMAGE_DEBUG" = "yes" ]; then
     PS4='$(date "+%s.%N ($LINENO) + ")'
@@ -60,122 +59,62 @@ trap "" SIGPIPE
 
 trap report_and_cleanup EXIT
 
-echo "Processing image with ID: \`$IMG_ID' and type: \`$IMAGE_TYPE'" >&2
+echo "Processing image with ID: \`$IMG_ID' and type: \`$IMG_FORMAT'" >&2
 
-case $BACKEND_TYPE in
-    local)
-        if [[ "$IMAGE_NAME" =~ ^local:// ]]; then
-            IMAGE_NAME="${IMAGE_NAME:8}"
-        elif [[ "$IMAGE_NAME" =~ ^file:// ]]; then
-            IMAGE_NAME="${IMAGE_NAME:7}"
-            log_warning "The file:// backend identifier is deprecated and" \
-                        "will be removed in the future. Use local:// instead."
-        fi
+echo "Using source backend \`$SRC_BACKEND_TYPE' and destination backend \`$DST_BACKEND_TYPE'" >&2
 
-        canonical_image_dir="$(canonicalize "$IMAGE_DIR")"
-        if [ ! -d "$canonical_image_dir" ]; then
-            log_error "The IMAGE_DIR directory: \`$IMAGE_DIR' does not exist."
-            report_error "Unable to retrieve image file."
-            exit 1
-        fi
-
-        image_file="$IMAGE_DIR/$IMAGE_NAME"
-        if [ ! -e "$image_file" ]; then
-            if [ -e "$image_file.$IMAGE_TYPE" ] ; then
-                image_file="$image_file.$IMAGE_TYPE"
-                log_warning "The \`.$IMAGE_TYPE' extension is missing from" \
-                    "the local backend id. This id form is deprecated and" \
-                    "will be remove in the future."
-            else
-                log_error "Image file \`$image_file' does not exist."
-                report_error "Unable to retrieve image file."
-                exit 1
-            fi
-        fi
-
-        canonical_image_file="$(canonicalize "$image_file")"
-
-        if [[ "$canonical_image_file" != "$canonical_image_dir"* ]]; then
-            log_error "Image ID points to a file outside the image directory: \`$IMAGE_DIR'"
-            report_error "Invalid image ID"
-            exit 1
-        fi
-
-        image_size="$(stat -L -c %s "$image_file")"
-        ;;
-    null)
-        # Since image copy will be skipped, image_size is the only var
-        # needed (see monitor command below)
-        image_size=0
-        ;;
-    network)
-        image_cmd="$CURL $(printf "%q" "$IMAGE_NAME")"
-        image_size=$($CURL -sI "$IMAGE_NAME" | grep ^Content-Length: | cut -d" " -f2)
-        ;;
-    pithos)
-        # For security reasons pass the various options to pithcat as
-        # environment variables.
-        export PITHCAT_DB="$PITHOS_DB"
-        export PITHCAT_DATA="$PITHOS_DATA"
-        export PITHCAT_BACKEND_STORAGE="$PITHOS_BACKEND_STORAGE"
-        export PITHCAT_RADOS_CEPH_CONF="$PITHOS_RADOS_CEPH_CONF"
-        export PITHCAT_RADOS_POOL_MAPS="$PITHOS_RADOS_POOL_MAPS"
-        export PITHCAT_RADOS_POOL_BLOCKS="$PITHOS_RADOS_POOL_BLOCKS"
-        export PITHCAT_ARCHIPELAGO_CONF="$PITHOS_ARCHIPELAGO_CONF"
-        cmd_args=""
-        if [ -n "${PITHCAT_UMASK+dummy}" ]; then
-            cmd_args="--umask=$PITHCAT_UMASK"
-        fi
-        cmd_args+=" $(printf "%q" "${IMAGE_NAME}")"
-        image_cmd="./pithcat $cmd_args"
-        image_size=$(./pithcat -s  $cmd_args)
-        ;;
-esac
-
-case "$IMAGE_TYPE" in
-    ntfsdump|extdump)
-        # Create a corresponding blockdev if required
-        blockdev=$(losetup_disk "$disk0")
-
-        # Create partitions on blockdev
-        format_disk0 "$blockdev" "$IMAGE_TYPE"
-
-        # Install a new MBR
-        $INSTALL_MBR -p 1 -i n "$blockdev"
-
-        target="$(map_disk0 "$blockdev")-1" #the root device
-        add_cleanup unmap_disk0 "$blockdev"
+case "$IMG_FORMAT" in
+    ntfsdump|extdump|diskdump)
         snf_export_PROPERTY_ROOT_PARTITION=1
-        if [ "$IMAGE_TYPE" = "ntfsdump" ]; then
+        if [ "$IMG_FORMAT" = "ntfsdump" ]; then
             snf_export_PROPERTY_OSFAMILY="windows"
         else
             snf_export_PROPERTY_OSFAMILY="linux"
         fi
         ;;
-    diskdump)
-        target="$disk0"
-        ;;
     *)
-        log_error "Unknown Image format: \`$IMAGE_TYPE'"
+        log_error "Unknown Image format: \`$IMG_FORMAT'"
         report_error "Unknown Image Format"
         exit 1
         ;;
 esac
 
-report_info "Starting image copy..."
-monitor="./copy-monitor.py -o $MONITOR_FD -r $image_size"
-if [ "$BACKEND_TYPE" = "null" ]; then
+if [ "$SRC_BACKEND_TYPE" = "null" ]; then
     report_info "Skipping image copy since no image provided (IMG_ID=null)..."
-elif [ "$BACKEND_TYPE" = "local" ]; then
-    # dd the dump to its new home :-)
-    # Deploying an image file on a target block device is a streaming copy
-    # operation. Enable the direct I/O flag on the output fd to avoid polluting
-    # the host cache with useless data.
-    $monitor $DD bs=4M if="$image_file" of="$target" oflag=direct iflag=fullblock
 else
-    $image_cmd | $monitor $DD bs=4M of="$target" oflag=direct iflag=fullblock
+    src_script=backends/src/${SRC_BACKEND_TYPE}
+    dst_script=backends/dst/${DST_BACKEND_TYPE}
+
+    if [ ! -x $src_script ]; then
+        log_error "Missing src script for backend type \`$SRC_BACKEND_TYPE'"
+        report_error "Unable to retrieve image"
+        exit 1
+    fi
+
+    if [ ! -x $dst_script ]; then
+        log_error "Missing dst script for backend type \`$DST_BACKEND_TYPE'"
+        report_error "Unable to copy image"
+        exit 1
+    fi
+
+    image_size=$($src_script -s $IMG_ID $IMG_FORMAT)
+
+    if [ -z "$image_size" ]; then
+        log_error "src script did not return a valid image size"
+        report_error "Unable to retrieve image size"
+        exit 1
+    fi
+
+    monitor="$PWD/copy-monitor.py -o $MONITOR_FD -r $image_size"
+
+    report_info "Starting image copy..."
+
+    $src_script $IMG_ID $IMG_FORMAT | $monitor $DD bs=1M | $dst_script $disk0 $IMG_FORMAT
+
+    report_info "Image copy finished."
+
 fi
-report_info "Image copy finished."
+
 
 # Create a floppy image
 floppy=$(mktemp --tmpdir floppy.XXXXXX)

--- a/snf-image-host/create
+++ b/snf-image-host/create
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2011-2015 GRNET S.A.
+# Copyright (C) 2011-2016 GRNET S.A. and individual contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -104,10 +104,9 @@ case $BACKEND_TYPE in
         image_size="$(stat -L -c %s "$image_file")"
         ;;
     null)
-        image_file=/dev/null
+        # Since image copy will be skipped, image_size is the only var
+        # needed (see monitor command below)
         image_size=0
-        # Treat it as local file from now on...
-        BACKEND_TYPE="local"
         ;;
     network)
         image_cmd="$CURL $(printf "%q" "$IMAGE_NAME")"
@@ -165,7 +164,9 @@ esac
 
 report_info "Starting image copy..."
 monitor="./copy-monitor.py -o $MONITOR_FD -r $image_size"
-if [ "$BACKEND_TYPE" = "local" ]; then
+if [ "$BACKEND_TYPE" = "null" ]; then
+    report_info "Skipping image copy since no image provided (IMG_ID=null)..."
+elif [ "$BACKEND_TYPE" = "local" ]; then
     # dd the dump to its new home :-)
     # Deploying an image file on a target block device is a streaming copy
     # operation. Enable the direct I/O flag on the output fd to avoid polluting


### PR DESCRIPTION
Hi,
These two patches make the process of image copying modular. This extends snf-image so it can copy images into disks that are neither local files nor kernel block devices, e.g., userspace-only disks.
Thanks,
dimara
