### PR TITLE
Fix filesystem corruption in case of a clean ext4 which needs recovery

### DIFF
--- a/snf-image-helper/common.sh.in
+++ b/snf-image-helper/common.sh.in
@@ -45,6 +45,7 @@ BASE64=base64
 NTFSINFO=ntfsinfo
 NTFSRESIZE=ntfsresize
 NTFSFIX=ntfsfix
+E2FSCK=e2fsck
 
 CLEANUP=( )
 ERRORS=( )

--- a/snf-image-helper/tasks/20FilesystemResizeUnmounted.in
+++ b/snf-image-helper/tasks/20FilesystemResizeUnmounted.in
@@ -74,11 +74,16 @@ if [[ "$ptype" == ext[234] ]]; then
     state=$($TUNE2FS -l "$device" | grep ^Filesystem\ state: | cut -d: -f2);
     state=$(echo $state) #trim the value
 
-    # We force a file system resize here if the file system is clean, even if
-    # resize2fs complains. By default resize2fs will refuse to resize a file
-    # system that has been mounted after the last fs check, but since we are
-    # sure the file system is clean it's safe enough to bypass this.
+    # NOTE: A filesystem might be clean but its journal may need recovery. This
+    # is typical when the filesystem is a snapshot of a running VM. So we do an
+    # fsck, which will fix the journal and then we resize the filesystem,
+    # otherwise we almost always end up with a corrupted filesystem and an
+    # un-bootable VM.
     if [ "$state" = "clean" ]; then
+        # NOTE: We use automatic repair (-p) because otherwise e2fsck complains
+        # that it needs a terminal for interactive repairs.
+        $E2FSCK -p "$device" || \
+            log_error "Filesytem was clean but fsck exited with error code $?"
         $EATMYDATA $RESIZE2FS -f "$device"
     else
         log_error "The file system state of partition: \`$device' " \


### PR DESCRIPTION
A filesystem might be clean but its journal may need recovery. This
is typical when the filesystem is a snapshot of a running VM. If we
run resize2fs -f on it, we almost always end up with a corrupted
filesystem and an un-bootable VM. This patch uses e2fsck before
resizing the filesystem and aborts if the former exits with errors.
