### PR TITLE
Feature cloud init

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -15,6 +15,14 @@ some external programs in ``/etc/default/snf-image``:
   # IMAGE_DEBUG: turn on debugging output for the scripts
   # IMAGE_DEBUG=no
 
+  # CLOUD_INIT_DEBUG: Turn cloud-init debug level on. If set to 'yes' and the
+  # instance is cloud-init enabled, snf-image-helper will inject into the
+  # instance a logging configuration for cloud-init that will log all messages
+  # with priority DEBUG or higher to /var/log/snf-image/cloud-init-debug.log.
+  # It will also prevent some cloud-init configuration files injected by
+  # snf-image-helper that contain sensitive data from being cleared out.
+  # CLOUD_INIT_DEBUG=no
+
   # VERSION_CHECK: Check if snf-image and snf-image-helper have the same version.
   # This is useful if snf-image is installed as Debian package and not from
   # source.

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -1,0 +1,7 @@
+Design
+======
+
+.. toctree::
+   :maxdepth: 1
+
+    (v0.22) Cloud-init support <design/cloud-init>

--- a/docs/design/cloud-init.rst
+++ b/docs/design/cloud-init.rst
@@ -1,0 +1,303 @@
+Adding cloud-init support to snf-image
+======================================
+
+How cloud-init works
+^^^^^^^^^^^^^^^^^^^^
+
+Cloud-init is a service that runs at VMs and performs VM configuration at an
+early boot stage. The instructions for performing the configuration can be
+collected from the configuration files and various implemented datasources.
+The configuration files of cloud-init are ``/etc/cloud/cloud.cfg`` and
+``/etc/cloud/cloud.cfg.d/*.cfg``. The datasources are sources for configuration
+data that typically come from the user or from the IaaS service itself (e.g the
+instance's name). Since different IaaS software use different mechanisms to
+provide configuration data to the instances (attaching configuration disks,
+using the kernel command line, using magic IPs, etc), multiple datasources are
+implemented.
+
+Why add support to snf-image
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If an image is configured to work with cloud-init, the service will destroy
+some of the changes that snf-image will make. Since most distributions provide
+cloud images that are configured to work with cloud-init, we would like to gain
+the benefit of working with official images. Additionally, a user will be able
+to further configure a VM that is created out of a cloud-init enabled image by
+using cloud-init's user data mechanism.
+
+Enabling cloud-init
+^^^^^^^^^^^^^^^^^^^
+
+In order to enable snf-image's cloud-init mode, the image should have set the
+CLOUD_INIT image property.
+
+Proposed changes
+^^^^^^^^^^^^^^^^
+
+Datasources
+-----------
+
+Since we want snf-image to be able to work stand-alone, without having to
+depend on external services, the software could only make use of 2 datasources:
+
+- NoCloud
+- None
+
+All the others expect to fetch data from an external entity (CDROM, Floppy,
+serial-port, web service) [#f1]_.
+
+"None" is the fallback datasource when no other can be selected. It is the
+equivalent of an empty datasource in that it provides an empty string as
+user data and an empty dictionary as metadata. We could make use of this and let
+*snf-image-helper* inject all it's configuration to files under
+``/etc/cloud/cloud.cfg.d/``. We could then allow the user to provide extra
+configuration data by using a new OS parameter (e.g. cloud_userdata) whose
+content would be injected into a file under ``/etc/cloud/cloud.cfg.d/``. The
+only problem with this approach is that the user may only provide YAML user
+data, which is not fully compatible with Openstack. The Nova API allows the
+user to provide user data upon server creation. Those user data are available
+in the OpenStack Metadata service to be consumed by cloud-init. Since we are
+using *snf-image* to build a stack that exposes an OpenStack compute API, it's
+highly discouraged to have an incompatibility by design.
+
+This leaves us with the "NoCloud" option. This datasource allows us to provide
+user data and metadata to the instance through a number of different ways. The
+most suitable for *snf-image* is the ``/var/lib/cloud/seed/nocloud-net``
+directory. The datasource will expect to find the files ``meta-data`` and
+``user-data`` and optionally ``vendor-data`` as well as ``network-config``
+under this directory. *snf-image* could use a dedicated task to create those
+files and write the following:
+
+.. code-block:: yaml
+
+  datasource_list: [NoCloud]
+
+to the cloud-init configuration. The various tasks could then perform their
+configuration by concatenating the ``meta-data`` and ``vendor-data`` files or
+by appending files to the cloud-init configuration directory. By definition,
+the best place for *snf-image* to put the configuration would be the
+``vendor-data`` file:
+
+  Vendordata is data provided by the entity that launches an instance (for
+  example, the cloud provider). This data can be used to customize the image to
+  fit into the particular environment it is being run in [#f2]_.
+
+Unfortunately, older versions of cloud-init don't play well with
+``vendor-data``, which leaves us with ``meta-data`` and the files under
+``/etc/cloud/cloud.cfg.d/``.
+
+Configuration Tasks
+-------------------
+
+*snf-image* configures the VM by running a number of configuration tasks on the
+hard disk of the VM. On images that support cloud-init, instead of directly
+altering the needed system files, *snf-image-helper* could add cloud-init
+configuration into the ``meta-data`` file as well as files under
+``/etc/cloud/cloud.cfg.d/``.
+
+The proposed changes for the configuration tasks are:
+
+**10FixPartitionTable**: The task should be prevented from running. Cloud-init
+will automatically grow the partition to consume the available space using the
+``growroot`` module of cloud-initramfs-tools and ``cc_growpart`` module.
+
+**20FilesystemResizeUnmounted**: This task should be prevented from running.
+Cloud-init will automatically enlarge the file system using the ``cc_resizefs``
+module.
+ 
+**30MountImage**: No changes are needed for this task.
+
+**35InstallUnattend**: This can stay intact or be prevented from running. It's
+Windows specific task and won't do anything against a Linux image.
+
+**40FilesystemResizeMounted**: This should be prevented from running.
+Cloud-init will use ``cc_resizefs`` module to grow the file system.
+
+**50AddSwap**: This task parses the content of the *SWAP* image property which
+cames in two forms (``<partition id>:<size>`` or ``<disk letter>``) and either
+creates a new swap partition or formats a whole disk to be used as swap. In 
+cloud-init, the swap configuration is performed by the ``cc_mount`` module.
+This module has a swap config key that can be used like this:
+
+.. code-block:: yaml
+
+  swap:
+    filename: <file>
+    size: <"auto"/size in bytes>
+    maxsize: <size in bytes>
+
+With this key we can add a swap file but not a swap partition. Since cloud-init
+does the partitioning itself and using swap files is as efficient as using
+partitions, in case the *SWAP* image property is defined in the first form,
+it's better if we just ignore the partition id and use the swap config key to
+create a swap file of the requested size instead.
+
+In case the *SWAP* property is defined in the second form and a swap disk is
+requested, we could make use of the ``mounts`` key of the ``cc_mounts`` module,
+to put the appropriate entry in fstab:
+
+
+.. code-block:: yaml
+
+  mounts:
+    - [ /dev/ephemeral-1, /mnt, auto, "defaults,noexec" ]
+    - [ sdc, /opt/data ]
+    - [ xvdh, /opt/data, "auto", "defaults,nofail", "0", "0" ]
+
+Unfortunately, this module does not support providing non ephemeral device
+names (UUID for swap) and using the standard device naming is error-prone.
+Hence, for swap disks, its better if we bypass cloud-init and let snf-image
+directly format the disk and put the swap entry to fstab.
+
+**50AssignHostname**: Adding a new ``local-hostname`` key in the metadata file
+should be enough to set the hostname. Alternatively, we could make use of the
+``cc_update_hostname`` module which supports the following keys:
+
+.. code-block:: yaml
+
+  preserve_hostname: <true/false>
+  fqdn: <fqdn>
+  hostname: <fqdn/hostname>
+
+We could ignore the fqdn key and use the other two.
+
+**50ChangeMachineId**: We should probably leave this intact. Newer cloud-init
+version will automatically change the machine ID to a random value as this task
+does, but allowing this task to run to make sure the machine ID is always
+altered even on images that user older versions of cloud-init won't harm.
+
+**50ChangePassword**: This task will change the password and inject SSH
+authorized keys to a list of users defined in the ``USERS`` image property. For
+changing the password of users, we could make use of the ``cc_set_password``
+module:
+
+.. code-block:: yaml
+
+    ssh_pwauth: <yes/no/unchanged>
+
+    password: password1
+    chpasswd:
+        expire: <true/false>
+
+    chpasswd:
+        list: |
+            user1:password1
+            user2:RANDOM
+            user3:password3
+            user4:R
+
+The ``password`` key only works for the default user and is not present in
+older versions of cloud-init, which leaves us with the ``chpasswd``. Using this
+key we can define the list of user-password tuples.
+
+Injecting SSH authorized keys to a list of users is not that easy. We can make
+the keys available to cloud-init by either setting the ``public-keys`` metadata
+key or using the ``ssh_authorized_keys`` config key. The ``cc_ssh`` module will
+inject the keys found there to the root, as well as the default user, if
+defined. The preferred way to do it is through the metadata service. This way
+we leave the ``ssh_authorized_keys`` config key for the user to add extra keys.
+
+**50ConfigureNetwork**: This task may use of cloud-init's ``net`` module.
+Cloud-init supports 3 network configuration formats [#f3]_:
+
+- Network Configuration ENI (Legacy)
+- Networking Config Version 1
+- Networking Config Version 2
+
+The first one is obsolete. We should probably use the version 1 of network
+config which is supported by most cloud-init enabled images. This format looks
+like this:
+
+.. code-block:: yaml
+
+  network:
+    version: 1
+    config:
+    - type: physical
+      name: eth0
+      subnets:
+        - type: dhcp
+
+*snf-image* should probably implement a new networking driver:
+``cloud-init.sh`` that uses the same interface as the other networking drivers
+of *snf-image* (``freebsd.sh``, ``ifcfg.sh``, ``ifupdown.sh``, ``netbsd.sh``,
+``nm.sh``, ``openbsd.sh.in``) and creates the networking configuration in the
+version 1 format. The only problem with this is that for IPv6 networks you
+cannot tell cloud-init whether slaac or slaac+dhcpv6 is to be used. This
+information is available in the Router Advertisement message and should be
+automatically determined by the OS upon receiving one, but many OSes do not
+respect it. In order to make sure that the networking works as expected in as
+many cases as possible, it's better if the cloud-init network configuration is
+only used as a last resort. If snf-image detects that it knows how to configure
+the instance's OS without using cloud-init, it should do so and instruct
+cloud-init to omit network configuration, by appending the following to
+cloud-init's configuration:
+
+.. code-block:: yaml
+
+  network: {config: disabled}
+
+**50DeleteSSHKeys**: This task shall set the ``ssh_deletekeys`` configuration
+key of the ``cc_ssh`` module.
+
+**50DisableRemoteDesktopConnections**: This can stay intact or be prevented
+from running. It's a Windows specific task and won't do anything against a
+Linux image.
+
+**50SELinuxAutorelabel**:  This can stay intact or be prevented from running.
+It's a Windows specific task and won't do anything against a Linux image.
+
+**60EnforcePersonality**: We could use the ``write_files`` key of the
+``cc_write_files`` module to create the files that need to be injected into the
+image. The problem is that if the user makes use of this key in the user-data,
+the original content will be overwritten and our files will be lost. It's
+better if we create a custom script under ``/var/lib/cloud/scripts/per-once``
+[#f4]_ to inject the files to their destination path at first boot and leave
+the ``write_files`` key for the user.
+
+**70RunCustomTask**: This should be kept intact.
+
+**80UmountImage**: This should be kept intact.
+
+**81FilesystemResizeAfterUmount**: This should be prevented from running. The
+``cc_resizefs`` module will do all the needed resizes.
+
+User-defined configuration
+--------------------------
+
+The user may provide extra configuration through a new ``cloud_userdata`` OS
+parameter. The content of this parameter is base64 encoded. If this parameter
+is set, the ``InitializeDatasource`` configuration task will decode and then
+inject its content to the ``/var/lib/cloud/seed/nocloud-net/user-data`` file.
+Cloud-init will treat this as user data and will handle the rest.
+
+Design Limitations
+------------------
+
+The users are statically defined in snf-image. The list of users whose password
+will change is defined in the USERS image property, which describes the image
+and not the instance. This is a problem because the user may provide user-data
+that will change the list of users that cloud-init will enable or create. By
+providing an new ``system_info`` list, the user may even change the name of the
+default user. *snf-image* has no way to determine that the *USERS* image
+property became obsolete because of provided user-data. We could solve this by
+introducing a new *users* OS parameter that will overwrite (if defined) the
+*USERS* image property and leave it to the user to make sure that the
+instance's users *snf-image* is aware of reflect the provided cloud-init
+configuration. This means that in order to use it in synnefo, we'll need add a
+custom extension to the OpenStack API. OpenStack does not suffer from this
+problem because it does not maintain a list of instance users to modify their
+login credentials at all. Cloud-init will insert ssh authorization keys
+to the root and the default users if available. Additionally, passwords are not
+auto-generated by the system. It is left to the user to decide on which
+instance users to change password and which passwords to use.
+
+.. rubric:: Footnotes
+
+.. [#f1] https://cloudinit.readthedocs.io/en/latest/topics/datasources.html#datasource-documentation
+
+.. [#f2] https://cloudinit.readthedocs.io/en/latest/topics/vendordata.html
+
+.. [#f3] https://cloudinit.readthedocs.io/en/latest/topics/network-config.html
+
+.. [#f4] http://cloudinit.readthedocs.io/en/latest/topics/dir_layout.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,7 @@ Contents:
    usage
    advanced
    development
+   design
 
 Indices and tables
 ==================

--- a/docs/interface.rst
+++ b/docs/interface.rst
@@ -26,6 +26,8 @@ following OS Parameters:
    deployment (windows-only)
  * **os_answer_file** (optional): an answer file used by Windows to automate
    the setup process, instead the default one (windows-only)
+ * **cloud_userdata** (optional): base64 encoded data to be used as cloud-init
+   user-data.
 
 .. _image-format:
 
@@ -238,6 +240,11 @@ All image formats properties
    form is specified, then a whole secondary disk will be configured
    to be swap. Defining *SWAP=c* will configure the third disk of the VM to be
    swap.This property only applies to Linux instances.
+
+ * **CLOUD_INIT=bool**
+   If this property is set, the configuration tasks will try to inject suitable
+   cloud-init configuration into the instance instead of directly altering
+   system files. This implies that the image has enabled cloud-init support.
 
  * **CUSTOM_TASK=<base64_encoded_content>**
    This property can be used to run a user-defined configuration task. The

--- a/snf-image-helper/autotools/ax_python_module.m4
+++ b/snf-image-helper/autotools/ax_python_module.m4
@@ -1,0 +1,49 @@
+# ===========================================================================
+#     http://www.gnu.org/software/autoconf-archive/ax_python_module.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PYTHON_MODULE(modname[, fatal])
+#
+# DESCRIPTION
+#
+#   Checks for Python module.
+#
+#   If fatal is non-empty then absence of a module will trigger an error.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Andrew Collier
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 6
+
+AU_ALIAS([AC_PYTHON_MODULE], [AX_PYTHON_MODULE])
+AC_DEFUN([AX_PYTHON_MODULE],[
+    if test -z $PYTHON;
+    then
+        PYTHON="python"
+    fi
+    PYTHON_NAME=`basename $PYTHON`
+    AC_MSG_CHECKING($PYTHON_NAME module: $1)
+	$PYTHON -c "import $1" 2>/dev/null
+	if test $? -eq 0;
+	then
+		AC_MSG_RESULT(yes)
+		eval AS_TR_CPP(HAVE_PYMOD_$1)=yes
+	else
+		AC_MSG_RESULT(no)
+		eval AS_TR_CPP(HAVE_PYMOD_$1)=no
+		#
+		if test -n "$2"
+		then
+			AC_MSG_ERROR(failed to find required module $1)
+			exit 1
+		fi
+	fi
+])

--- a/snf-image-helper/common.sh.in
+++ b/snf-image-helper/common.sh.in
@@ -1130,20 +1130,40 @@ detect_image_properties() {
 }
 
 get_cloud_init_config() {
-    local target cfg_d confname
+    local target cfg_d cfg confname rm_cfg
     target="$1"
     confname="$2"
+    rm_cfg="$target/var/lib/cloud/scripts/per-once/rm_$(basename "$confname").sh"
+
+    mkdir -p $(dirname "$rm_cfg")
 
     for i in "" "local"; do
         cfg_d="$target/$i/etc/cloud/cloud.cfg.d"
 
         if [ -d "$cfg_d" ]; then
+            cfg="$cfg_d/$confname"
+
             echo "$cfg_d/$confname"
+
+            # Make sure the files created by snf-image are removed at first boot
+            { printf "#!/bin/sh\nrm -f %s" "${cfg##$target}"; } > "$rm_cfg"
+            if [ -z "$SNF_IMAGE_CLOUD_INIT_DEBUG" ]; then
+                chmod +x "$rm_cfg"
+            fi
+
             return
         fi
     done
 
     log_error "Unable to find directory to host the cloud-init configuration"
+}
+
+get_cloud_init_seed() {
+    local target seed
+    target="$1"
+    seed="$target/var/lib/cloud/seed/nocloud-net"
+    mkdir -p "$seed"
+    echo "$seed"
 }
 
 encode_array() {

--- a/snf-image-helper/common.sh.in
+++ b/snf-image-helper/common.sh.in
@@ -56,6 +56,7 @@ MSG_TYPE_TASK_END="TASK_END"
 
 STDERR_LINE_SIZE=10
 
+
 add_cleanup() {
     local cmd=""
     for arg; do cmd+=$(printf "%q " "$arg"); done
@@ -158,6 +159,10 @@ prepare_helper() {
 task_init_as() {
     declare -A attr
     export TASKNAME="$PROGNAME"
+
+    if check_yes_no SNF_IMAGE_PROPERTY_CLOUD_INIT; then
+        export CLOUD_INIT_CONFNAME="98_snf-image-${TASKNAME}.cfg"
+    fi
 
     trap task_cleanup EXIT
     report_task_start
@@ -1122,6 +1127,23 @@ detect_image_properties() {
             break
         fi
     done
+}
+
+get_cloud_init_config() {
+    local target cfg_d confname
+    target="$1"
+    confname="$2"
+
+    for i in "" "local"; do
+        cfg_d="$target/$i/etc/cloud/cloud.cfg.d"
+
+        if [ -d "$cfg_d" ]; then
+            echo "$cfg_d/$confname"
+            return
+        fi
+    done
+
+    log_error "Unable to find directory to host the cloud-init configuration"
 }
 
 encode_array() {

--- a/snf-image-helper/common.sh.in
+++ b/snf-image-helper/common.sh.in
@@ -46,6 +46,7 @@ NTFSINFO=ntfsinfo
 NTFSRESIZE=ntfsresize
 NTFSFIX=ntfsfix
 E2FSCK=e2fsck
+BASE64=base64
 
 CLEANUP=( )
 ERRORS=( )

--- a/snf-image-helper/common.sh.in
+++ b/snf-image-helper/common.sh.in
@@ -160,6 +160,9 @@ prepare_helper() {
 task_init_as() {
     declare -A attr
     export TASKNAME="$PROGNAME"
+    local exclude exclude_msg
+    exclude="SNF_IMAGE_PROPERTY_EXCLUDE_TASK_$(tr [a-z] [A-Z] <<< ${PROGNAME:2})"
+    exclude_msg="Task ${PROGNAME:2} was excluded and will not run."
 
     if check_yes_no SNF_IMAGE_PROPERTY_CLOUD_INIT; then
         export CLOUD_INIT_CONFNAME="98_snf-image-${TASKNAME}.cfg"
@@ -174,20 +177,37 @@ task_init_as() {
     done
 
     if [ -n "${attr[excludable]}" ]; then
-        check_if_excluded
+        if check_yes_no "$exclude"; then
+            warn "$exclude_msg"
+            exit 0
+        fi
     fi
 
     if [ -n "${attr[fs_resize_excludable]}" ]; then
-        check_if_filesystem_resize_excluded
+        if check_yes_no SNF_IMAGE_PROPERTY_EXCLUDE_FILESYSTEMRESIZE_TASKS; then
+            warn "$exclude_msg"
+            exit 0
+        fi
     fi
 
     if [ -n "${attr[mounted_excludable]}" ]; then
-        check_if_mounted_excluded
+        if check_yes_no SNF_IMAGE_PROPERTY_EXCLUDE_MOUNTED_TASKS; then
+            warn "$exclude_msg"
+            exit 0
+        fi
+    fi
+
+    if [ -n "${attr[cloudinit_excludable]}" ]; then
+        if check_yes_no SNF_IMAGE_PROPERTY_CLOUD_INIT; then
+            warn "Task ${PROGNAME:2} not running when cloud-init enabled."
+            exit 0
+        fi
     fi
 
     if [ -n "${attr[overwritable]}" ]; then
         check_if_overwritten
     fi
+
 }
 
 report_error() {
@@ -1256,36 +1276,6 @@ check_yes_no() {
         warn "Invalid value for variable: \`$name' (=$value). Will treat this as a \`YES'"
         return 0
     fi
-}
-
-check_if_excluded() {
-    local name exclude
-    name="$(tr [a-z] [A-Z] <<< ${PROGNAME:2})"
-    exclude="SNF_IMAGE_PROPERTY_EXCLUDE_TASK_${name}"
-    if check_yes_no "$exclude"; then
-        warn "Task ${PROGNAME:2} was excluded and will not run."
-        exit 0
-    fi
-
-    return 0
-}
-
-check_if_mounted_excluded() {
-    if check_yes_no SNF_IMAGE_PROPERTY_EXCLUDE_MOUNTED_TASKS; then
-        warn "Task ${PROGNAME:2} was excluded and will not run."
-        exit 0
-    fi
-
-    return 0
-}
-
-check_if_filesystem_resize_excluded() {
-    if check_yes_no SNF_IMAGE_PROPERTY_EXCLUDE_FILESYSTEMRESIZE_TASKS; then
-        warn "Task ${PROGNAME:2} was excluded and will not run."
-        exit 0
-    fi
-
-    return 0
 }
 
 check_if_overwritten() {

--- a/snf-image-helper/common.sh.in
+++ b/snf-image-helper/common.sh.in
@@ -155,6 +155,35 @@ prepare_helper() {
     export HYPERVISOR
 }
 
+task_init_as() {
+    declare -A attr
+    export TASKNAME="$PROGNAME"
+
+    trap task_cleanup EXIT
+    report_task_start
+
+    while (( "$#" )); do
+        attr["$1"]=yes
+        shift
+    done
+
+    if [ -n "${attr[excludable]}" ]; then
+        check_if_excluded
+    fi
+
+    if [ -n "${attr[fs_resize_excludable]}" ]; then
+        check_if_filesystem_resize_excluded
+    fi
+
+    if [ -n "${attr[mounted_excludable]}" ]; then
+        check_if_mounted_excluded
+    fi
+
+    if [ -n "${attr[overwritable]}" ]; then
+        check_if_overwritten
+    fi
+}
+
 report_error() {
     msg=""
     if [ ${#ERRORS[*]} -eq 0 ]; then
@@ -1219,9 +1248,14 @@ check_if_filesystem_resize_excluded() {
 check_if_overwritten() {
     local script ret
 
+    if [ ! -d "$SNF_IMAGE_TARGET" ]; then
+        log_error "Target dir: \`$SNF_IMAGE_TARGET' is missing."
+    fi
+
     if ! check_yes_no SNF_IMAGE_PROPERTY_ALLOW_MOUNTED_TASK_OVERWRITING; then
         return 0
     fi
+
     script=$(find -L $SNF_IMAGE_TARGET/root/snf-image/helper \
              -iname "overwrite_task_${PROGNAME:2}" -type f 2>/dev/null) || true
     if [ -x "$script" ]; then

--- a/snf-image-helper/configure.ac
+++ b/snf-image-helper/configure.ac
@@ -58,6 +58,11 @@ if test -z "$HIVEXREGEDIT" ; then
   AC_MSG_ERROR([hivexregedit not found in $PATH])
 fi
 
+#Python Dependencies
+AM_PATH_PYTHON(2.6)
+
+AC_PYTHON_MODULE(yaml, t)
+
 AC_CONFIG_FILES([
     Makefile
     tasks/Makefile

--- a/snf-image-helper/inject-files.py
+++ b/snf-image-helper/inject-files.py
@@ -19,9 +19,9 @@
 
 """Inject files into a directory
 
-This program injects files into a target directory.
-The files are passed to the program through a JSON string either read from a
-file or from standard input.
+This program injects files into a target directory or creates a cloud-init
+configuration for the cc_write_files module. The files are passed to the
+program through a JSON string either read from a file or from standard input.
 
 """
 
@@ -30,7 +30,8 @@ import os
 import json
 import datetime
 import base64
-from optparse import OptionParser
+import argparse
+import yaml
 
 
 def timestamp():
@@ -39,44 +40,58 @@ def timestamp():
     return current_time
 
 
-def parse_arguments(input_args):
-    usage = "Usage: %prog [options] <target>"
-    parser = OptionParser(usage=usage)
-    parser.add_option("-i", "--input",
-                      action="store", type='string', dest="input_file",
-                      help="get input from FILE instead of stdin",
-                      metavar="FILE")
-    parser.add_option("-d", "--decode", action="store_true", dest="decode",
-                      default=False,
-                      help="decode files under target and create manifest")
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-t", "--target", dest="target", metavar="DIRECTORY",
+                        help="write files to DIRECTORY")
+    parser.add_argument("-i", "--input", dest="input_file", metavar="FILE",
+                        help="get input from FILE instead of stdin")
+    parser.add_argument("-d", "--decode", action="store_true", dest="decode",
+                        default=False,
+                        help="decode files under target and create manifest")
+    parser.add_argument("-c", "--cloud-init", default=False, dest="cloudinit",
+                        action="store_true",
+                        help="decode files to a cloud-init configuration")
 
-    opts, args = parser.parse_args(input_args)
+    args = parser.parse_args()
 
-    if len(args) != 1:
-        parser.error('target is missing')
+    if not args.target and not args.cloudinit:
+        parser.error('Either -t or -c must be defined!')
 
-    target = args[0]
-    if not os.path.isdir(target):
-        parser.error('target is not a directory')
+    if args.target and args.cloudinit:
+        parser.error('Options -t and -c are mutual exclusive')
 
-    input_file = opts.input_file
-    if input_file is None:
-        input_file = sys.stdin
-    else:
-        if not os.path.isfile(input_file):
-            parser.error('input file does not exist')
-        input_file = open(input_file, 'r')
+    if args.target is not None and not os.path.isdir(args.target):
+        parser.error('Defined target: %s is not a directory' % args.target)
 
-    return (input_file, target, opts.decode)
+    if args.input_file is not None and not os.path.isfile(args.input_file):
+        parser.error('input file does not exist')
+
+    return args
 
 
 def main():
-    (input_file, target, decode) = parse_arguments(sys.argv[1:])
+    args = parse_arguments()
 
-    files = json.load(input_file, strict=False)
+    input_stream = open(args.input_file, 'r') if args.input_file else sys.stdin
+    files = json.load(input_stream, strict=False)
 
-    if decode:
-        manifest = open(target + '/manifest', 'w')
+    if args.cloudinit:
+        out = {}
+        out['write_files'] = []
+        for f in files:
+            out['write_files'].append(
+                {'owner': str("%s:%s" % (f.get('owner', 'root'),
+                                         f.get('group', 'root'))),
+                 'permissions': f.get('mode', 0440),
+                 'content': str(f['contents']),
+                 'encoding': str('b64'),
+                 'path': str(f['path'])})
+        print yaml.dump(out, default_flow_style=False)
+        return 0
+
+    if args.decode:
+        manifest = open(args.target + '/manifest', 'w')
 
     count = 0
     for f in files:
@@ -85,8 +100,8 @@ def main():
         group = f['group'] if 'group' in f else ""
         mode = f['mode'] if 'mode' in f else 0440
 
-        filepath = f['path'] if not decode else str(count)
-        filepath = target + "/" + filepath
+        filepath = f['path'] if not args.decode else str(count)
+        filepath = args.target + "/" + filepath
 
         if os.path.lexists(filepath):
             backup_file = filepath + '.bak.' + timestamp()
@@ -100,14 +115,14 @@ def main():
         newfile.write(base64.b64decode(f['contents']))
         newfile.close()
 
-        if decode:
+        if args.decode:
             manifest.write("%s\x00%s\x00%s\x00%o\x00%s\x00" %
                            (count, owner, group, mode, f['path']))
 
-    if decode:
+    if args.decode:
         manifest.close()
 
-    input_file.close()
+    input_stream.close()
     return 0
 
 if __name__ == "__main__":

--- a/snf-image-helper/networking/Makefile.am
+++ b/snf-image-helper/networking/Makefile.am
@@ -1,6 +1,6 @@
 networkingdir=$(libdir)/$(PACKAGE)/networking
 
-dist_networking_SCRIPTS = ifupdown.sh ifcfg.sh freebsd.sh openbsd.sh netbsd.sh nm.sh
+dist_networking_SCRIPTS = ifupdown.sh ifcfg.sh freebsd.sh openbsd.sh netbsd.sh nm.sh cloud-init.sh
 
 edit = sed \
            -e 's|@sysconfdir[@]|$(sysconfdir)|g' \

--- a/snf-image-helper/networking/cloud-init.sh.in
+++ b/snf-image-helper/networking/cloud-init.sh.in
@@ -1,0 +1,78 @@
+#! /bin/bash
+
+# Copyright (C) 2017 GRNET S.A.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+# Script for writing cloud-init network configurations
+
+set -e
+. "@commondir@/common.sh"
+
+ARGS=( "$@" )
+networking_opts "$@"
+
+SEED=$(get_cloud_init_seed "$SNF_IMAGE_TARGET")
+CFG="$SEED/network-config"
+
+
+if [ "$initialize" = yes ]; then
+    cat >> "$CFG" <<EOF
+version: 1
+config:
+EOF
+    exit 0
+fi
+
+
+if [ "$finalize" = yes ]; then
+    exit 0
+fi
+
+cat >> "$CFG" <<EOF
+  - type: physical
+    name: eth$index
+    mac_address: $MAC
+EOF
+
+subnets=""
+
+if [ "$ipv4" = "dhcp" ]; then
+    subnets="      - type: dhcp"
+elif [ "$ipv4" = "static" ]; then
+    subnets="      - type: static"
+    if [ -n "$IP" -a -n "$SUBNET" ]; then
+        subnets="        address: $IP/${SUBNET##*/}"
+    fi
+    if [ -n "$GATEWAY" ]; then
+        subnets="        gateway: $GATEWAY"
+    fi
+fi
+
+if [ -n "$subnets" ]; then
+    cat >> "$CFG" <<EOF
+    subnets:
+$subnets
+EOF
+fi
+
+# Fallback to ENI
+echo "network-interfaces: |" >> "$SEED/meta-data"
+export INTERFACES=$(mktemp)
+@networkingdir@/ifupdown.sh "${ARGS[@]}"
+sed 's/^/  /' "$INTERFACES" >> "$SEED/meta-data"
+
+# vim: set sta sts=4 shiftwidth=4 sw=4 et ai :

--- a/snf-image-helper/networking/ifupdown.sh.in
+++ b/snf-image-helper/networking/ifupdown.sh.in
@@ -21,7 +21,7 @@
 set -e
 . "@commondir@/common.sh"
 
-INTERFACES="$SNF_IMAGE_TARGET/etc/network/interfaces"
+: ${INTERFACES:="$SNF_IMAGE_TARGET/etc/network/interfaces"}
 
 networking_opts "$@"
 

--- a/snf-image-helper/tasks/10FixPartitionTable.in
+++ b/snf-image-helper/tasks/10FixPartitionTable.in
@@ -20,16 +20,14 @@
 ### BEGIN TASK INFO
 # Provides:		FixPartitionTable
 # RunBefore:		FilesystemResizeUnmounted
+# RunAfter:
 # Short-Description:	Enlarge last partition to use all the available space
 ### END TASK INFO
 
 set -e
 . "@commondir@/common.sh"
 
-trap task_cleanup EXIT
-report_task_start
-# Check if the task should be prevented from running.
-check_if_excluded
+task_init_as excludable
 
 if [ ! -b "$SNF_IMAGE_DEV" ]; then
     log_error "Device file:\`${SNF_IMAGE_DEV}' is not a block device"

--- a/snf-image-helper/tasks/10FixPartitionTable.in
+++ b/snf-image-helper/tasks/10FixPartitionTable.in
@@ -27,7 +27,7 @@
 set -e
 . "@commondir@/common.sh"
 
-task_init_as excludable
+task_init_as excludable cloudinit_excludable
 
 if [ ! -b "$SNF_IMAGE_DEV" ]; then
     log_error "Device file:\`${SNF_IMAGE_DEV}' is not a block device"

--- a/snf-image-helper/tasks/20FilesystemResizeUnmounted.in
+++ b/snf-image-helper/tasks/20FilesystemResizeUnmounted.in
@@ -27,12 +27,7 @@
 set -e
 . "@commondir@/common.sh"
 
-trap task_cleanup EXIT
-report_task_start
-
-# Check if the task should be prevented from running.
-check_if_excluded
-check_if_filesystem_resize_excluded
+task_init_as excludable fs_resize_excludable
 
 if [ ! -b "$SNF_IMAGE_DEV" ]; then
     log_error "Device file:\`${SNF_IMAGE_DEV}' is not a block device"

--- a/snf-image-helper/tasks/20FilesystemResizeUnmounted.in
+++ b/snf-image-helper/tasks/20FilesystemResizeUnmounted.in
@@ -27,7 +27,7 @@
 set -e
 . "@commondir@/common.sh"
 
-task_init_as excludable fs_resize_excludable
+task_init_as excludable fs_resize_excludable cloudinit_excludable
 
 if [ ! -b "$SNF_IMAGE_DEV" ]; then
     log_error "Device file:\`${SNF_IMAGE_DEV}' is not a block device"

--- a/snf-image-helper/tasks/30MountImage.in
+++ b/snf-image-helper/tasks/30MountImage.in
@@ -20,17 +20,14 @@
 ### BEGIN TASK INFO
 # Provides:		MountImage
 # RunBefore:		UmountImage
+# RunAfter:
 # Short-Description:	Mount the partition that hosts the image
 ### END TASK INFO
 
 set -e
 . "@commondir@/common.sh"
 
-trap task_cleanup EXIT
-report_task_start
-
-# Check if the task should be prevented from running
-check_if_mounted_excluded
+task_init_as mounted_excludable
 
 if [ ! -d "$SNF_IMAGE_TARGET" ]; then
     log_error "Target dir:\`$SNF_IMAGE_TARGET' is missing"

--- a/snf-image-helper/tasks/35InitializeDatasource.in
+++ b/snf-image-helper/tasks/35InitializeDatasource.in
@@ -1,0 +1,88 @@
+#! /bin/bash
+
+# Copyright (C) 2017 GRNET S.A.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+### BEGIN TASK INFO
+# Provides:		InitializeDatasource
+# RunBefore:		EnforcePersonality
+# RunAfter:		MountImage
+# Short-Description:	Initialized the cloud-init NoCloud datasource
+### END TASK INFO
+
+set -e
+. "@commondir@/common.sh"
+
+task_init_as mounted_excludable overwritable
+
+if ! check_yes_no SNF_IMAGE_PROPERTY_CLOUD_INIT; then
+    warn "Cloud-init not enabled for this instance"
+    return 0
+fi
+
+CFG=$(get_cloud_init_config "$SNF_IMAGE_TARGET" "$CLOUD_INIT_CONFNAME")
+
+cat >> $CFG <<EOF
+datasource_list: [ NoCloud ]
+EOF
+
+if [ -n "$SNF_IMAGE_CLOUD_INIT_DEBUG" ]; then
+    mkdir -p "$SNF_IMAGE_TARGET/var/log/snf-image"
+    cat >> "$CFG" <<-EOF
+	logcfg: |
+	  [loggers]
+	  keys=root,cloudinit
+	  [handlers]
+	  keys=ch,cf
+	  [formatters]
+	  keys=
+	  [logger_root]
+	  level=DEBUG
+	  handlers=
+	  [logger_cloudinit]
+	  level=DEBUG
+	  qualname=cloudinit
+	  handlers=ch,cf
+	  [handler_ch]
+	  class=StreamHandler
+	  level=DEBUG
+	  args=(sys.stderr,)
+	  [handler_cf]
+	  class=FileHandler
+	  level=DEBUG
+	  args=('/var/log/snf-image/cloud-init-debug.log',)
+	EOF
+fi
+
+SEED=$(get_cloud_init_seed "$SNF_IMAGE_TARGET")
+
+echo "instance-id: $SNF_IMAGE_HOSTNAME" > "$SEED/meta-data"
+touch "$SEED/user-data"
+
+# Remove the created files that may contain sensitive user data at first boot
+SCRIPT="$SNF_IMAGE_TARGET/var/lib/cloud/scripts/per-once/clear_seed.sh"
+cat > "$SCRIPT" <<EOF
+#!/bin/sh
+rm -f ${SEED##$SNF_IMAGE_TARGET}/*
+EOF
+if [ -z "$SNF_IMAGE_CLOUD_INIT_DEBUG" ]; then
+    chmod +x "$SCRIPT"
+fi
+
+exit 0
+
+# vim: set sta sts=4 shiftwidth=4 sw=4 et ai :

--- a/snf-image-helper/tasks/35InitializeDatasource.in
+++ b/snf-image-helper/tasks/35InitializeDatasource.in
@@ -71,7 +71,13 @@ fi
 SEED=$(get_cloud_init_seed "$SNF_IMAGE_TARGET")
 
 echo "instance-id: $SNF_IMAGE_HOSTNAME" > "$SEED/meta-data"
-touch "$SEED/user-data"
+
+if [ -n "$SNF_IMAGE_CLOUD_USERDATA" ]; then
+    $BASE64 -d > "$SEED/user-data" <<< "$SNF_IMAGE_CLOUD_USERDATA"
+else
+    warn "No cloud user-data provided"
+    touch "$SEED/user-data"
+fi
 
 # Remove the created files that may contain sensitive user data at first boot
 SCRIPT="$SNF_IMAGE_TARGET/var/lib/cloud/scripts/per-once/clear_seed.sh"

--- a/snf-image-helper/tasks/35InstallUnattend.in
+++ b/snf-image-helper/tasks/35InstallUnattend.in
@@ -27,18 +27,7 @@
 set -e
 . "@commondir@/common.sh"
 
-trap task_cleanup EXIT
-report_task_start
-
-# Check if the task should be prevented from running.
-check_if_mounted_excluded
-
-if [ -z "$SNF_IMAGE_TARGET" ]; then
-    log_error "Target dir: \`$SNF_IMAGE_TARGET' is missing"
-fi
-
-# Check if the image overwrites the task
-check_if_overwritten
+task_init_as mounted_excludable overwritable cloudinit_excludable
 
 if [[ ! "$SNF_IMAGE_PROPERTY_OSFAMILY" =~ ^windows ]]; then
     exit 0

--- a/snf-image-helper/tasks/40FilesystemResizeMounted.in
+++ b/snf-image-helper/tasks/40FilesystemResizeMounted.in
@@ -27,7 +27,7 @@
 set -e
 . "@commondir@/common.sh"
 
-task_init_as excludable mounted_excludable fs_resize_excludable overwritable
+task_init_as excludable mounted_excludable fs_resize_excludable overwritable cloudinit_excludable
 
 if [ ! -b "$SNF_IMAGE_DEV" ]; then
     log_error "Device file:\`${SNF_IMAGE_DEV}' is not a block device"

--- a/snf-image-helper/tasks/40FilesystemResizeMounted.in
+++ b/snf-image-helper/tasks/40FilesystemResizeMounted.in
@@ -27,20 +27,7 @@
 set -e
 . "@commondir@/common.sh"
 
-trap task_cleanup EXIT
-report_task_start
-
-# Check if the task should be prevented from running.
-check_if_excluded
-check_if_mounted_excluded
-check_if_filesystem_resize_excluded
-
-if [ ! -d "$SNF_IMAGE_TARGET" ]; then
-    log_error "Target directory \`$SNF_IMAGE_TARGET' is missing"
-fi
-
-# Check if the image overwrites the task
-check_if_overwritten
+task_init_as excludable mounted_excludable fs_resize_excludable overwritable
 
 if [ ! -b "$SNF_IMAGE_DEV" ]; then
     log_error "Device file:\`${SNF_IMAGE_DEV}' is not a block device"

--- a/snf-image-helper/tasks/50AddSwap.in
+++ b/snf-image-helper/tasks/50AddSwap.in
@@ -27,19 +27,7 @@
 set -e
 . "@commondir@/common.sh"
 
-trap task_cleanup EXIT
-report_task_start
-
-# Check if the task should be prevented from running.
-check_if_excluded
-check_if_mounted_excluded
-
-if [ ! -d "$SNF_IMAGE_TARGET" ]; then
-    log_error "Target dir: \`$SNF_IMAGE_TARGET' is missing."
-fi
-
-# Check if the image overwrites the task
-check_if_overwritten
+task_init_as excludable mounted_excludable overwritable
 
 if [ "$SNF_IMAGE_PROPERTY_OSFAMILY" != "linux" ]; then
     exit 0

--- a/snf-image-helper/tasks/50AddSwap.in
+++ b/snf-image-helper/tasks/50AddSwap.in
@@ -27,7 +27,7 @@
 set -e
 . "@commondir@/common.sh"
 
-task_init_as excludable mounted_excludable overwritable
+task_init_as excludable mounted_excludable overwritable cloudinit_excludable
 
 if [ "$SNF_IMAGE_PROPERTY_OSFAMILY" != "linux" ]; then
     exit 0

--- a/snf-image-helper/tasks/50AddSwap.in
+++ b/snf-image-helper/tasks/50AddSwap.in
@@ -27,7 +27,7 @@
 set -e
 . "@commondir@/common.sh"
 
-task_init_as excludable mounted_excludable overwritable cloudinit_excludable
+task_init_as excludable mounted_excludable overwritable
 
 if [ "$SNF_IMAGE_PROPERTY_OSFAMILY" != "linux" ]; then
     exit 0
@@ -41,9 +41,20 @@ fi
 if [[ "$SNF_IMAGE_PROPERTY_SWAP" =~ ^(([A-Za-z])|(([1-9]([0-9])*):([1-9]([0-9])*)))$ ]]; then
     swap_disk=${BASH_REMATCH[2],,}  # Make it lowercase
     swap_id=${BASH_REMATCH[4]}
+    swap_size=${BASH_REMATCH[6]}
 
     if [ -n "$swap_id" ]; then
-        swap_dev="${SNF_IMAGE_DEV}${swap_id}"
+        if check_yes_no SNF_IMAGE_PROPERTY_CLOUD_INIT; then
+            # ignore the partition and create a swap file
+            CFG=$(get_cloud_init_config "$SNF_IMAGE_TARGET" "$CLOUD_INIT_CONFNAME")
+            echo "swap:" > "$CFG"
+            echo "  filename: /swap-${RANDOM}.img" >> "$CFG"
+            echo "  size: auto" >> "$CFG"
+            echo "  maxsize: $((swap_size*1024*1024))" >> "$CFG"
+            exit 0
+        else
+            swap_dev="${SNF_IMAGE_DEV}${swap_id}"
+        fi
     else
         letters=( {a..z} )
         for ((i=0; i < ${#letters[@]}; i++)); do
@@ -70,6 +81,7 @@ fi
 $MKSWAP "$swap_dev"
 
 UUID=$(cut -d" " -f2 <<< $($BLKID -s UUID "$swap_dev"))
+
 
 if [ -f "$SNF_IMAGE_TARGET/etc/fstab" ]; then
     echo -e "$UUID\tnone\tswap\tsw\t0\t0" >> "$SNF_IMAGE_TARGET/etc/fstab"

--- a/snf-image-helper/tasks/50AssignHostname.in
+++ b/snf-image-helper/tasks/50AssignHostname.in
@@ -27,19 +27,7 @@
 set -e
 . "@commondir@/common.sh"
 
-trap task_cleanup EXIT
-report_task_start
-
-# Check if the task should be prevented from running.
-check_if_excluded
-check_if_mounted_excluded
-
-if [ ! -d "$SNF_IMAGE_TARGET" ]; then
-    log_error "Target dir: \`$SNF_IMAGE_TARGET' is missing"
-fi
-
-# Check if the image overwrites the task
-check_if_overwritten
+task_init_as excludable mounted_excludable overwritable
 
 windows-legacy_hostname() {
     local target hostname sysprepinf

--- a/snf-image-helper/tasks/50AssignHostname.in
+++ b/snf-image-helper/tasks/50AssignHostname.in
@@ -153,6 +153,19 @@ netbsd_hostname() {
     fi
 }
 
+cloud_init_hostname() {
+    local target hostname seed metadata
+    target="$1"
+    hostname="$2"
+    seed="$(get_cloud_init_seed "$target")"
+    metadata="$seed/meta-data"
+
+    cat >> "$metadata" <<-EOF
+	local-hostname: $hostname
+	EOF
+}
+
+
 if [ ! -d "$SNF_IMAGE_TARGET" ]; then
     log_error "Target dir: \`$SNF_IMAGE_TARGET' is missing"
 fi
@@ -161,7 +174,11 @@ if [ -z "$SNF_IMAGE_HOSTNAME" ]; then
     log_error "Hostname is missing"
 fi
 
-${SNF_IMAGE_PROPERTY_OSFAMILY}_hostname "$SNF_IMAGE_TARGET" "$SNF_IMAGE_HOSTNAME"
+if check_yes_no SNF_IMAGE_PROPERTY_CLOUD_INIT; then
+    cloud_init_hostname "$SNF_IMAGE_TARGET" "$SNF_IMAGE_HOSTNAME"
+else
+    ${SNF_IMAGE_PROPERTY_OSFAMILY}_hostname "$SNF_IMAGE_TARGET" "$SNF_IMAGE_HOSTNAME"
+fi
 
 exit 0
 

--- a/snf-image-helper/tasks/50ChangeMachineId.in
+++ b/snf-image-helper/tasks/50ChangeMachineId.in
@@ -27,19 +27,7 @@
 set -e
 . "@commondir@/common.sh"
 
-trap task_cleanup EXIT
-report_task_start
-
-# Check if the task should be prevented from running.
-check_if_excluded
-check_if_mounted_excluded
-
-if [ ! -d "$SNF_IMAGE_TARGET" ]; then
-    log_error "Target dir: \`$SNF_IMAGE_TARGET' is missing."
-fi
-
-# Check if the image overwrites the task
-check_if_overwritten
+task_init_as excludable mounted_excludable overwritable
 
 if [ "$SNF_IMAGE_PROPERTY_OSFAMILY" != "linux" ]; then
     exit 0

--- a/snf-image-helper/tasks/50ChangePassword.in
+++ b/snf-image-helper/tasks/50ChangePassword.in
@@ -138,6 +138,7 @@ windows_password() {
 unix_auth() {
     local flavor target password encrypted users usr tmp_shadow method home opt
     local default_method keys entry keys_file keys_file_tmpl new_entry uid guid
+    local seed cfg
 
     while getopts 'f:k:m:p:t:' opt; do
         case $opt in
@@ -193,6 +194,26 @@ unix_auth() {
         fi
     fi
 
+    if check_yes_no SNF_IMAGE_PROPERTY_CLOUD_INIT; then
+        seed=$(get_cloud_init_seed "$SNF_IMAGE_TARGET")
+        cfg=$(get_cloud_init_config "$SNF_IMAGE_TARGET" "$CLOUD_INIT_CONFNAME")
+
+        if [ -n "${password+dummy}" ]; then
+            echo "ssh_pwauth: True" >> "$cfg"
+        fi
+
+        if [ -n "${keys+dummy}" ]; then
+            echo "public-keys:" >> "$seed/meta-data"
+            while read line; do
+                # trim the line
+                line="$(echo $line)"
+                if [ -n "$line" ]; then
+                    echo "  - $line" >> "$seed/meta-data"
+                fi
+            done <<< "${keys}"
+        fi
+    fi
+
     if [ -n "${keys}" ]; then
         # Find the value of the AuthorizedKeysFile keyword if present in
         # sshd_config. For more info check:
@@ -215,7 +236,20 @@ unix_auth() {
         users+=("root")
     fi
 
+    if check_yes_no SNF_IMAGE_PROPERTY_CLOUD_INIT; then
+        if [ -n "${password}" ]; then
+            echo "chpasswd:" >> "$cfg"
+            echo "  expire: false" >> "$cfg"
+            echo "  list: |" >> "$cfg"
+            for usr in "${users[@]}"; do
+                echo "    ${usr}:${password}" >> "$cfg"
+            done
+        fi
+        return
+    fi
+
     for usr in "${users[@]}"; do
+
         if [ -n "${password+dummy}" ]; then
             echo -n "Setting ${usr} password ... "
 

--- a/snf-image-helper/tasks/50ChangePassword.in
+++ b/snf-image-helper/tasks/50ChangePassword.in
@@ -27,19 +27,7 @@
 set -e
 . "@commondir@/common.sh"
 
-trap task_cleanup EXIT
-report_task_start
-
-# Check if the task should be prevented from running.
-check_if_excluded
-check_if_mounted_excluded
-
-if [ ! -d "$SNF_IMAGE_TARGET" ]; then
-    log_error "Target dir: \`$SNF_IMAGE_TARGET' is missing"
-fi
-
-# Check if the image overwrites the task
-check_if_overwritten
+task_init_as excludable mounted_excludable overwritable
 
 linux_shadow="/etc/shadow"
 freebsd_shadow="/etc/master.passwd"

--- a/snf-image-helper/tasks/50ConfigureNetwork.in
+++ b/snf-image-helper/tasks/50ConfigureNetwork.in
@@ -32,9 +32,20 @@ task_init_as excludable mounted_excludable overwritable
 networking_tool=$(get_networking_tool "$SNF_IMAGE_TARGET")
 
 if [ ! -f "$networking_tool" ]; then
-    warn "Don't know how to configure the network for this OS"
-    exit 0
+    if check_yes_no SNF_IMAGE_PROPERTY_CLOUD_INIT; then
+        warn "Don't know how to configure the network. Letting cloud-init do that..."
+        networking_tool=@networkingdir@/cloud-init.sh
+    else
+        warn "Don't know how to configure the network for this OS"
+        exit 0
+    fi
 else
+    # If we know how to configure the network, it's better if we do it ourself.
+    # From what I've seen we can do it better than cloud-init.
+    if check_yes_no SNF_IMAGE_PROPERTY_CLOUD_INIT; then
+        CFG=$(get_cloud_init_config "$SNF_IMAGE_TARGET" "$CLOUD_INIT_CONFNAME")
+        echo "network: {config: disabled}" > "$CFG"
+    fi
     echo "Using $networking_tool"
 fi
 

--- a/snf-image-helper/tasks/50ConfigureNetwork.in
+++ b/snf-image-helper/tasks/50ConfigureNetwork.in
@@ -27,20 +27,7 @@
 set -e
 . "@commondir@/common.sh"
 
-
-trap task_cleanup EXIT
-report_task_start
-
-# Check if the task should be prevented from running.
-check_if_excluded
-check_if_mounted_excluded
-
-if [ ! -d "$SNF_IMAGE_TARGET" ]; then
-    log_error "Target dir: \`$SNF_IMAGE_TARGET' is missing"
-fi
-
-# Check if the image overwrites the task
-check_if_overwritten
+task_init_as excludable mounted_excludable overwritable
 
 networking_tool=$(get_networking_tool "$SNF_IMAGE_TARGET")
 

--- a/snf-image-helper/tasks/50DeleteSSHKeys.in
+++ b/snf-image-helper/tasks/50DeleteSSHKeys.in
@@ -27,19 +27,7 @@
 set -e
 . "@commondir@/common.sh"
 
-trap task_cleanup EXIT
-report_task_start
-
-# Check if the task should be prevented from running.
-check_if_excluded
-check_if_mounted_excluded
-
-if [ ! -d "$SNF_IMAGE_TARGET" ]; then
-    log_error "Target dir: \`$SNF_IMAGE_TARGET' is missing."
-fi
-
-# Check if the image overwrites the task
-check_if_overwritten
+task_init_as excludable mounted_excludable overwritable
 
 if [[ "$SNF_IMAGE_PROPERTY_OSFAMILY" =~ ^windows ]]; then
     exit 0

--- a/snf-image-helper/tasks/50DeleteSSHKeys.in
+++ b/snf-image-helper/tasks/50DeleteSSHKeys.in
@@ -27,7 +27,7 @@
 set -e
 . "@commondir@/common.sh"
 
-task_init_as excludable mounted_excludable overwritable
+task_init_as excludable mounted_excludable overwritable cloudinit_excludable
 
 if [[ "$SNF_IMAGE_PROPERTY_OSFAMILY" =~ ^windows ]]; then
     exit 0

--- a/snf-image-helper/tasks/50DeleteSSHKeys.in
+++ b/snf-image-helper/tasks/50DeleteSSHKeys.in
@@ -27,7 +27,13 @@
 set -e
 . "@commondir@/common.sh"
 
-task_init_as excludable mounted_excludable overwritable cloudinit_excludable
+task_init_as excludable mounted_excludable overwritable
+
+if check_yes_no SNF_IMAGE_PROPERTY_CLOUD_INIT; then
+    CFG=$(get_cloud_init_config "$SNF_IMAGE_TARGET" "$CLOUD_INIT_CONFNAME")
+    echo "ssh_deletekeys: true" >> "$CFG"
+    exit 0
+fi
 
 if [[ "$SNF_IMAGE_PROPERTY_OSFAMILY" =~ ^windows ]]; then
     exit 0

--- a/snf-image-helper/tasks/50DisableRemoteDesktopConnections.in
+++ b/snf-image-helper/tasks/50DisableRemoteDesktopConnections.in
@@ -27,7 +27,7 @@
 set -e
 . "@commondir@/common.sh"
 
-task_init_as excludable mounted_excludable overwritable
+task_init_as excludable mounted_excludable overwritable cloudinit_excludable
 
 # This task will change the value of `fDenyTSConnections' registry key located
 # under `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server\'

--- a/snf-image-helper/tasks/50DisableRemoteDesktopConnections.in
+++ b/snf-image-helper/tasks/50DisableRemoteDesktopConnections.in
@@ -24,7 +24,11 @@
 # Short-Description:	Temporary Disable Remote Desktop Connections
 ### END TASK INFO
 
-#
+set -e
+. "@commondir@/common.sh"
+
+task_init_as excludable mounted_excludable overwritable
+
 # This task will change the value of `fDenyTSConnections' registry key located
 # under `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server\'
 # to "true". This will disable RDP connections while the machine is being
@@ -34,23 +38,6 @@
 # is not set unconditionally to False, but is re-set to its original value
 # instead, thus preserving Image-specific policy of whether RDP is enabled
 # or not.
-
-set -e
-. "@commondir@/common.sh"
-
-trap task_cleanup EXIT
-report_task_start
-
-# Check if the task should be prevented from running.
-check_if_excluded
-check_if_mounted_excluded
-
-if [ ! -d "$SNF_IMAGE_TARGET" ]; then
-    log_error "Target directory \`$SNF_IMAGE_TARGET' is missing"
-fi
-
-# Check if the image overwrites the task
-check_if_overwritten
 
 if [[ ! "$SNF_IMAGE_PROPERTY_OSFAMILY" =~ ^windows ]]; then
     exit 0

--- a/snf-image-helper/tasks/50SELinuxAutorelabel.in
+++ b/snf-image-helper/tasks/50SELinuxAutorelabel.in
@@ -27,21 +27,7 @@
 set -e
 . "@commondir@/common.sh"
 
-trap task_cleanup EXIT
-report_task_start
-
-# Check if the task should be prevented from running
-check_if_mounted_excluded
-
-# Check if the task should be prevented from running.
-check_if_excluded
-
-if [ ! -d "$SNF_IMAGE_TARGET" ]; then
-	log_error "Target dir: \`$SNF_IMAGE_TARGET' is missing"	
-fi
-
-# Check if the image overwrites the task
-check_if_overwritten
+task_init_as excludable mounted_excludable overwritable
 
 if [ "$SNF_IMAGE_PROPERTY_OSFAMILY" = "linux" ]; then
     distro=$(get_base_distro $SNF_IMAGE_TARGET)

--- a/snf-image-helper/tasks/60EnforcePersonality.in
+++ b/snf-image-helper/tasks/60EnforcePersonality.in
@@ -28,22 +28,7 @@ set -e
 
 . "@commondir@/common.sh"
 
-trap task_cleanup EXIT
-report_task_start
-
-# Check if the task should be prevented from running.
-check_if_excluded
-check_if_mounted_excluded
-
-# Default mode for directories
-DIRMODE="750"
-
-if [ ! -d "$SNF_IMAGE_TARGET" ]; then
-    log_error "Target dir: \`$SNF_IMAGE_TARGET' is missing"
-fi
-
-# Check if the image overwrites the task
-check_if_overwritten
+task_init_as excludable mounted_excludable overwritable
 
 if [ -z "$SNF_IMAGE_PERSONALITY" ]; then
     warn "This image has no personality (0 files to inject)"

--- a/snf-image-helper/tasks/60EnforcePersonality.in
+++ b/snf-image-helper/tasks/60EnforcePersonality.in
@@ -35,16 +35,58 @@ if [ -z "$SNF_IMAGE_PERSONALITY" ]; then
     exit 0
 fi
 
+if check_yes_no SNF_IMAGE_PROPERTY_CLOUD_INIT; then
+
+    tmpdir=$(env TMPDIR="$SNF_IMAGE_TARGET/var/lib/cloud/scripts/per-once" mktemp -d)
+    echo "$SNF_IMAGE_PERSONALITY" |
+        @scriptsdir@/inject-files.py -d -t "$tmpdir"
+
+    script="$SNF_IMAGE_TARGET/var/lib/cloud/scripts/per-once/inject_files-${RANDOM}.sh"
+
+    cat > $script <<EOF
+#!/bin/bash
+
+while read -d \$'\0' src; do
+    read -d \$'\0' owner
+    read -d \$'\0' group
+    read -d \$'\0' mode
+    read -d \$'\0' dest
+
+    if [ -n "\$owner" ]; then
+        owner="-g \$owner"
+    fi
+
+    if [ -n "\$group" ]; then
+        group="-g \$group"
+    fi
+
+    if [ -n "\$mode" ]; then
+        mode="-m \$mode"
+    fi
+
+    mkdir -p \`dirname \$dest\`
+
+    install \$uid \$gid \$mode "${tmpdir##$SNF_IMAGE_TARGET}/\$src" "\$dest"
+done < "${tmpdir##$SNF_IMAGE_TARGET}/manifest"
+
+rm -rf "${tmpdir##$SNF_IMAGE_TARGET}" "\$0"
+EOF
+
+chmod +x "$script"
+exit 0
+
+fi
+
 if [[ "$SNF_IMAGE_PROPERTY_OSFAMILY" =~ ^windows ]]; then
     echo "$SNF_IMAGE_PERSONALITY" |
-        @scriptsdir@/inject-files.py "$SNF_IMAGE_TARGET"
+        @scriptsdir@/inject-files.py -t "$SNF_IMAGE_TARGET"
     exit 0
 else
 
     tmpdir=$(mktemp -d)
     add_cleanup rm -rf "$tmpdir"
     echo "$SNF_IMAGE_PERSONALITY" |
-        @scriptsdir@/inject-files.py -d "$tmpdir"
+        @scriptsdir@/inject-files.py -d -t "$tmpdir"
 
     { while read -d $'\0' src; do
         read -d $'\0' owner

--- a/snf-image-helper/tasks/70RunCustomTask.in
+++ b/snf-image-helper/tasks/70RunCustomTask.in
@@ -28,19 +28,7 @@ set -e
 
 . "@commondir@/common.sh"
 
-trap task_cleanup EXIT
-report_task_start
-
-# Check if the task should be prevented from running.
-check_if_excluded
-check_if_mounted_excluded
-
-if [ ! -d "$SNF_IMAGE_TARGET" ]; then
-    log_error "Target dir: \`$SNF_IMAGE_TARGET' is missing"
-fi
-
-# Check if the image overwrites the task
-check_if_overwritten
+task_init_as excludable mounted_excludable overwritable
 
 if [ -z "$SNF_IMAGE_PROPERTY_CUSTOM_TASK" ]; then
     warn "No custom task specified to run"

--- a/snf-image-helper/tasks/80UmountImage.in
+++ b/snf-image-helper/tasks/80UmountImage.in
@@ -27,11 +27,7 @@
 set -e
 . "@commondir@/common.sh"
 
-trap task_cleanup EXIT
-report_task_start
-
-# Check if the task should be prevented from running
-check_if_mounted_excluded
+task_init_as mounted_excludable
 
 if [ ! -d "$SNF_IMAGE_TARGET" ]; then
     log_error "Target dir:\`$SNF_IMAGE_TARGET' is missing"

--- a/snf-image-helper/tasks/81FilesystemResizeAfterUmount.in
+++ b/snf-image-helper/tasks/81FilesystemResizeAfterUmount.in
@@ -27,11 +27,7 @@
 set -e
 . "@commondir@/common.sh"
 
-trap task_cleanup EXIT
-report_task_start
-# Check if the task should be prevented from running.
-check_if_excluded
-check_if_filesystem_resize_excluded
+task_init_as excludable fs_resize_excludable
 
 if [ ! -b "$SNF_IMAGE_DEV" ]; then
     log_error "Device file:\`${SNF_IMAGE_DEV}' is not a block device"

--- a/snf-image-helper/tasks/81FilesystemResizeAfterUmount.in
+++ b/snf-image-helper/tasks/81FilesystemResizeAfterUmount.in
@@ -27,7 +27,7 @@
 set -e
 . "@commondir@/common.sh"
 
-task_init_as excludable fs_resize_excludable
+task_init_as excludable fs_resize_excludable cloudinit_excludable
 
 if [ ! -b "$SNF_IMAGE_DEV" ]; then
     log_error "Device file:\`${SNF_IMAGE_DEV}' is not a block device"

--- a/snf-image-helper/tasks/Makefile.am
+++ b/snf-image-helper/tasks/Makefile.am
@@ -4,6 +4,7 @@ dist_tasks_SCRIPTS = \
 		10FixPartitionTable \
 		20FilesystemResizeUnmounted \
 		30MountImage \
+		35InitializeDatasource \
 		35InstallUnattend \
 		40FilesystemResizeMounted \
 		50AddSwap \

--- a/snf-image-host/common.sh.in
+++ b/snf-image-host/common.sh.in
@@ -539,6 +539,7 @@ fi
 : ${VARIANTS_DIR:="@sysconfdir@/ganeti/snf-image/variants"}
 : ${IMAGE_DIR:="@localstatedir@/lib/snf-image"}
 : ${IMAGE_DEBUG:="no"}
+: ${CLOUD_INIT_DEBUG:="no"}
 : ${VERSION_CHECK:="@VERSION_CHECK@"}
 : ${HELPER_DIR:="@HELPER_DIR@"}
 : ${HELPER_SOFT_TIMEOUT:=120}

--- a/snf-image-host/common.sh.in
+++ b/snf-image-host/common.sh.in
@@ -138,7 +138,7 @@ get_api20_arguments() {
 
         osparams=(IMG_ID IMG_FORMAT IMG_PASSWD IMG_PASSWD_HASH IMG_PROPERTIES
                   IMG_PERSONALITY CONFIG_URL OS_PRODUCT_KEY OS_ANSWER_FILE
-                  AUTH_KEYS)
+                  AUTH_KEYS CLOUD_USERDATA)
 
         # Store OSP_VAR in VAR
         for param in "${osparams[@]}"; do

--- a/snf-image-host/create
+++ b/snf-image-host/create
@@ -37,6 +37,12 @@ elif [ "$IMAGE_DEBUG" != "no" ]; then
     log_warning "Unsupported IMAGE_DEBUG value: \`$IMAGE_DEBUG'"
 fi
 
+if [ "$CLOUD_INIT_DEBUG" = "yes" ]; then
+    snf_export_CLOUD_INIT_DEBUG="$CLOUD_INIT_DEBUG"
+elif [ "$CLOUD_INIT_DEBUG" != "no" ]; then
+    log_warning "Unsupported CLOUD_INIT_DEBUG value: \`$CLOUD_INIT_DEBUG'"
+fi
+
 monitor_pipe=$(mktemp -u)
 mkfifo -m 600 "$monitor_pipe"
 add_cleanup rm -f "$monitor_pipe"

--- a/snf-image-host/create
+++ b/snf-image-host/create
@@ -216,6 +216,10 @@ if [ -n "${AUTH_KEYS+dummy}" ]; then
     snf_export_AUTH_KEYS="$AUTH_KEYS"
 fi
 
+if [ -n "${CLOUD_USERDATA+dummy}" ]; then
+    snf_export_CLOUD_USERDATA="$CLOUD_USERDATA"
+fi
+
 assign_disk_devices_to snf_export_DEV
 
 create_floppy "$floppy"

--- a/snf-image-host/defaults.in
+++ b/snf-image-host/defaults.in
@@ -6,6 +6,14 @@
 # IMAGE_DEBUG: turn on debugging output for the scripts
 # IMAGE_DEBUG=no
 
+# CLOUD_INIT_DEBUG: Turn cloud-init debug level on. If set to 'yes' and the
+# instance is cloud-init enabled, snf-image-helper will inject into the
+# instance a logging configuration for cloud-init that will log all messages
+# with priority DEBUG or higher to /var/log/snf-image/cloud-init-debug.log. It
+# will also prevent some cloud-init configuration files injected by
+# snf-image-helper that contain sensitive data from being cleared out.
+# CLOUD_INIT_DEBUG=no
+
 # VERSION_CHECK: Check if snf-image and snf-image-helper have the same version.
 # This is useful if snf-image is installed as Debian package and not from
 # source.

--- a/snf-image-host/multistrap.conf
+++ b/snf-image-host/multistrap.conf
@@ -21,7 +21,7 @@ debootstrap=Debian GRNet Helper OldHelper
 aptsources=Debian
 
 [Debian]
-packages=socat iproute xenstore-utils xmlstarlet python parted python-support eatmydata gdisk ntfs-3g python-passlib libhivex-bin libwin-hivex-perl btrfs-tools xfsprogs python-bcrypt upstart gawk
+packages=socat iproute xenstore-utils xmlstarlet python parted python-support eatmydata gdisk ntfs-3g python-passlib libhivex-bin libwin-hivex-perl btrfs-tools xfsprogs python-bcrypt upstart gawk python-yaml
 source=http://ftp.gr.debian.org/debian
 suite=jessie
 

--- a/snf-image-host/parameters.list
+++ b/snf-image-host/parameters.list
@@ -8,3 +8,4 @@ auth_keys Keys to append to the users' authorized keys files for remote log in
 os_product_key A product key to be used to license a Windows deployment (windows-only)
 os_answer_file An answer file used by Windows to automate the setup process (windows-only)
 config_url The URL to download configuration data from
+cloud_userdata User-data to inject to cloud-init (base64 encoded)

--- a/snf-image-host/verify
+++ b/snf-image-host/verify
@@ -23,14 +23,16 @@ set -e
 
 
 check_required() {
-    local required_params="IMG_ID IMG_FORMAT"
-    local osparams="$required_params IMG_PASSWD IMG_PROPERTIES IMG_PERSONALITY CONFIG_URL OS_PRODUCT_KEY OS_ANSWER_FILE AUTH_KEYS"
+    local required_params=(IMG_ID IMG_FORMAT)
+    local osparams=(${required_params[@]} IMG_PASSWD IMG_PROPERTIES
+                    IMG_PERSONALITY CONFIG_URL OS_PRODUCT_KEY OS_ANSWER_FILE
+                    AUTH_KEYS CLOUD_USERDATA)
     local osp
 
     source_variant
 
     # Store OSP_VAR in VAR
-    for param in $osparams; do
+    for param in "${osparams[@]}"; do
         # Only do the evaluation if OSP_$param is defined
         osp="OSP_$param"
         if [ -n "${!osp+dummy}" ]; then
@@ -38,8 +40,7 @@ check_required() {
         fi
     done
 
-
-    for var in $required_params; do
+    for var in ${required_params[@]}; do
         if [ -z "${!var}" ]; then
              log_error "Missing OS API Parameter: ${var,,}"
              exit 1
@@ -51,7 +52,6 @@ check_required() {
         log_error "Valid values are \`diskdump', \`extdump' and \`ntfsdump'"
         exit 1
     fi
-
 
     if [ -n "${OS_PRODUCT_KEY+dummy}" ]; then
         if [[ ! "${OS_PRODUCT_KEY}" =~ ^([a-zA-Z0-9]{5}-){4}[a-zA-Z0-9]{5}$ ]]; then


### PR DESCRIPTION
Add cloud-init support for snf-image. If the `CLOUD_INIT` image property is enabled, snf-image-helper tasks will, instead of altering system files, inject suitable cloud-init configuration to the instance.